### PR TITLE
Unable to run after installation

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -73,7 +73,7 @@
                                     "platform": "Linux"
                                 },
                                 "caption": "Key Bindings – User"
-                            },
+                            }
 						]
 					}
 				]


### PR DESCRIPTION
Installation via Package Manager failed pointing to a trailing comma in this file. Removing it made open appear in the menu and it works using the hotkey.
